### PR TITLE
Corriger quelques obstacles à l'installation de l'application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,7 @@ data/
 *#
 *.#*
 local.py
+*.iml
+*.iws
+*.ipr
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ db.sqlite3
 local_settings.py
 env
 dev.db
+dev.db-journal
 data/
 *#
 *.#*

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ simplejson
 beautifulsoup4
 mimeparse
 progressbar
+pytz


### PR DESCRIPTION
Il y un problème lors de l'installation de l'application sur ma plateforme Mac OS X:
- La librairie `pytz` est manquante lors de l'exécution du script _syncdata_.

Également, quelques entrées ont été ajoutées dans le fichier `.gitignore`:
- Les fichiers de projet pour IntelliJ IDEA.
- Le fichier journal de la DB SQLite.
